### PR TITLE
Add homework 11 with tests.

### DIFF
--- a/Lesson_11/homework_10.py
+++ b/Lesson_11/homework_10.py
@@ -1,0 +1,38 @@
+"""Homework 11.1.
+
+You and your team are developing a system login for a web application,
+and you need to implement tests for the login function.
+Given a function, write a set of tests for it.
+"""
+
+import logging
+
+
+def log_event(username: str, status: str):
+    """Login event logging.
+
+    Args:
+        username (str): The user name that logs in to the system.
+        status (str): Login event status:
+
+    * success - successful, logs in at info level
+    * expired - the password is out of date and should be replaced,
+                logs at the warning level
+    * failed  - the password is incorrect, it is logged at the error level
+    """
+    log_message = f'Login event - Username: {username}, Status: {status}'
+
+    # Logger creation and configuring
+    logging.basicConfig(
+        filename='login_system.log',
+        level=logging.INFO,
+        format='%(asctime)s - %(message)s')
+    logger = logging.getLogger('log_event')
+
+    # Event logging
+    if status == 'success':
+        logger.info(log_message)
+    elif status == 'expired':
+        logger.warning(log_message)
+    else:
+        logger.error(log_message)

--- a/Lesson_11/pytest.ini
+++ b/Lesson_11/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
-log_format = %(asctime)s - %(levelname)s - %(message)s
+log_format = %(asctime)s.%(msecs)03d : %(module)-12s:%(lineno)3d %(levelname)-7s - %(message)s 
 log_date_format = %Y-%m-%d %H:%M:%S
+log_cli = true
+log_level = DEBUG
+; log_cli_format = %(asctime)s - %(levelname)s - %(message)s
+; log_cli_date_format = %Y-%m-%d %H:%M:%S

--- a/Lesson_11/pytest.ini
+++ b/Lesson_11/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+log_format = %(asctime)s - %(levelname)s - %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S

--- a/Lesson_11/test_homework_10.py
+++ b/Lesson_11/test_homework_10.py
@@ -1,0 +1,74 @@
+"""Tests for homework #10 log event login function."""
+
+import pytest
+
+from homework_10 import log_event
+
+test_data = [
+    ('user1', 'success', 'INFO'),
+    ('user2', 'expired', 'WARNING'),
+    ('user3', 'failed', 'ERROR'),
+    ('user4', None, 'ERROR'),  # Invalid case.
+    (None, 'failed', 'ERROR'),  # Invalid case.
+    (None, None, 'ERROR'),  # Invalid case.
+    ('', '', 'ERROR')]  # Invalid case.
+
+
+@pytest.mark.parametrize('user, status, expected_log_level', test_data)
+def test_log_event_statuses(caplog, user, status, expected_log_level):
+    """Test logging for different login event statuses.
+
+    Args:
+        caplog (LogCaptureFixture): Captured logs pytest fixture.
+        user (string): Logged user's username.
+        status (string): Logged user's status.
+        expected_log_level (string): Logged event level.
+    """
+    with caplog.at_level(expected_log_level):
+        log_event(user, status)
+
+    expected_message = f'Login event - Username: {user}, Status: {status}'
+
+    # Verify the correct message is logged
+    assert expected_message in caplog.text, 'Wrong message.'
+    # Verify the log level is correct
+    assert caplog.records[0].levelname == expected_log_level, 'Wrong log level'
+    # Display entire caplog text.
+
+    print(caplog.text)
+
+
+# Test case for log event message output.
+@pytest.mark.parametrize('user, status, expected_log_level', test_data)
+def test_log_event_message_format(caplog, user, status, expected_log_level):
+    """Test logging message output.
+
+    Args:
+        caplog (LogCaptureFixture): Captured logs pytest fixture.
+        user (string): Logged user's username.
+        status (string): Logged user's status.
+        expected_log_level (string): Logged event level.
+    """
+    with caplog.at_level(expected_log_level):
+        log_event(user, status)
+
+    # Verify that event log level is correct.
+    assert expected_log_level in caplog.text, 'Wrong event log level.'
+    # Verify for the separator between timestamp and message.
+    assert ' - L' in caplog.text, 'Separator is missed or message was changed.'
+    # Verify the timestamp is present and starts with a year.
+    assert caplog.text.startswith('2024-'), ('Timestamp is missed.')
+
+    # For clarification what is in caplog.records.
+    for record in caplog.records:
+        print('')
+        print('-' * 40)
+        print(f'Log Record: {record}')
+        print(f'Levelname: {record.levelname}')
+        print(f'Message: {record.message}')
+        print(f'Created: {record.created}')
+        print(f'Logger Name: {record.name}')
+        print(f'Levelno: {record.levelno}')
+        print('-' * 40)
+    # Display entire caplog text.
+    print(caplog.text)

--- a/Lesson_11/test_homework_10.py
+++ b/Lesson_11/test_homework_10.py
@@ -15,6 +15,7 @@ test_data = [
 ]
 
 
+# Test case for log event statuses.
 @pytest.mark.parametrize('user, status, expected_log_level', test_data)
 def test_log_event_statuses(caplog, user, status, expected_log_level):
     """Test logging for different login event statuses.

--- a/Lesson_11/test_homework_10.py
+++ b/Lesson_11/test_homework_10.py
@@ -11,7 +11,8 @@ test_data = [
     ('user4', None, 'ERROR'),  # Invalid case.
     (None, 'failed', 'ERROR'),  # Invalid case.
     (None, None, 'ERROR'),  # Invalid case.
-    ('', '', 'ERROR')]  # Invalid case.
+    ('', '', 'ERROR'),  # Invalid case.
+]
 
 
 @pytest.mark.parametrize('user, status, expected_log_level', test_data)
@@ -33,9 +34,6 @@ def test_log_event_statuses(caplog, user, status, expected_log_level):
     assert expected_message in caplog.text, 'Wrong message.'
     # Verify the log level is correct
     assert caplog.records[0].levelname == expected_log_level, 'Wrong log level'
-    # Display entire caplog text.
-
-    print(caplog.text)
 
 
 # Test case for log event message output.
@@ -57,18 +55,4 @@ def test_log_event_message_format(caplog, user, status, expected_log_level):
     # Verify for the separator between timestamp and message.
     assert ' - L' in caplog.text, 'Separator is missed or message was changed.'
     # Verify the timestamp is present and starts with a year.
-    assert caplog.text.startswith('2024-'), ('Timestamp is missed.')
-
-    # For clarification what is in caplog.records.
-    for record in caplog.records:
-        print('')
-        print('-' * 40)
-        print(f'Log Record: {record}')
-        print(f'Levelname: {record.levelname}')
-        print(f'Message: {record.message}')
-        print(f'Created: {record.created}')
-        print(f'Logger Name: {record.name}')
-        print(f'Levelno: {record.levelno}')
-        print('-' * 40)
-    # Display entire caplog text.
-    print(caplog.text)
+    assert caplog.text.startswith('2024-'), 'Timestamp is missed.'


### PR DESCRIPTION
Add homework 11 with tests.
Use: Pytest caplog() fixture.

Linters errors: 
Unable to find qualified name for module: test_homework_10.py.
S101 Use of assert detected. The enclosed code will be removed when compiling to optimised byte code.

error S101 - add to ignored 'flake8 --ignore WPS,S101', no sure if it is correct.